### PR TITLE
se movieron los titles al card-header

### DIFF
--- a/client/views/home.html
+++ b/client/views/home.html
@@ -7,10 +7,10 @@
     <div class="columns">
         <div class="column">
             <div class="card">
+                <div class="card-header">
+                    <p class="card-header-title">Gastos mensuales</p>
+                </div>
                 <div class="card-content">
-                    <h2 class="subtitle is-3 has-text-centered">
-                        Gastos mensuales
-                    </h2>
                     <div style="width: 100%; height: 320px">
                         <canvas data-ref="monthExpenses"></canvas>
                     </div>
@@ -32,10 +32,10 @@
     <div class="columns">
         <div class="column">
             <div class="card">
+                <div class="card-header">
+                    <p class="card-header-title">Balance mensual</p>
+                </div>
                 <div class="card-content">
-                    <h2 class="subtitle is-3 has-text-centered">
-                        Balance mensual
-                    </h2>
                     <div style="width: 100%; height: 300px">
                         <canvas data-ref="monthBalance"></canvas>
                     </div>


### PR DESCRIPTION
Creo que si usamos cards para subdividir el tablero, deberíamos separar siempre  `card-header ` y `card-content`.